### PR TITLE
ci: disable py312 until torch available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py: ["3.10", "3.11", "3.12"]
+        # PyTorch wheels are not yet available for Python 3.12
+        py: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- avoid testing Python 3.12 in CI until PyTorch wheels support it

## Testing
- `ruff check src tests` *(fails: Found 46 errors)*
- `mypy src` *(fails: module type errors in slicer)*
- `pytest -q --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'adaptive_dynamics')*

------
https://chatgpt.com/codex/tasks/task_e_68b8b1d45ad8832fb6f579415100f1ca